### PR TITLE
SD-4206: Fix `slack_personal_message` arguments to make example valid

### DIFF
--- a/actions/cookbook.md
+++ b/actions/cookbook.md
@@ -144,7 +144,7 @@ rules:
         - tags='api_change' or tags='database_migration'
       actions:
         - slack_personal_message:
-            user: sara@example.com
+            email: sara@example.com
             message: |
               An important <{{deploy_url}}|deployment> went out tagged with {{deploy_tags}}.
 ```


### PR DESCRIPTION
The change of `user` -> `email` makes the snippet valid in the
validator: https://app.sleuth.io/sleuth/sleuth/actions/validator